### PR TITLE
Model versus seeder/migration discrepancy

### DIFF
--- a/src/migrations/20230313124654-create-account.js
+++ b/src/migrations/20230313124654-create-account.js
@@ -2,7 +2,7 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable('Accounts', {
+    await queryInterface.createTable('accounts', {
       id: {
         allowNull: false,
         autoIncrement: true,
@@ -31,6 +31,6 @@ module.exports = {
     });
   },
   async down(queryInterface, Sequelize) {
-    await queryInterface.dropTable('Accounts');
+    await queryInterface.dropTable('accounts');
   }
 };

--- a/src/migrations/20230313124715-create-endpoint.js
+++ b/src/migrations/20230313124715-create-endpoint.js
@@ -2,7 +2,7 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable('Endpoints', {
+    await queryInterface.createTable('endpoints', {
       id: {
         allowNull: false,
         autoIncrement: true,
@@ -44,6 +44,6 @@ module.exports = {
     });
   },
   async down(queryInterface, Sequelize) {
-    await queryInterface.dropTable('Endpoints');
+    await queryInterface.dropTable('endpoints');
   }
 };

--- a/src/seeders/20230313124606-demo-accounts.js
+++ b/src/seeders/20230313124606-demo-accounts.js
@@ -3,7 +3,7 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up (queryInterface, Sequelize) {
-    return queryInterface.bulkInsert('Accounts', [{
+    return queryInterface.bulkInsert('accounts', [{
       quicknode_id: '1234567890',
       plan: 'discover',
       is_test: true,
@@ -13,6 +13,6 @@ module.exports = {
   },
 
   async down (queryInterface, Sequelize) {
-    return queryInterface.bulkDelete('Accounts', null, {});
+    return queryInterface.bulkDelete('accounts', null, {});
   }
 };

--- a/src/seeders/20230313124607-demo-endpoints.js
+++ b/src/seeders/20230313124607-demo-endpoints.js
@@ -3,7 +3,7 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up (queryInterface, Sequelize) {
-    return queryInterface.bulkInsert('Endpoints', [{
+    return queryInterface.bulkInsert('endpoints', [{
       quicknode_id: '1234567890',
       account_id: 1,
       chain: 'ethereum',
@@ -17,6 +17,6 @@ module.exports = {
   },
 
   async down (queryInterface, Sequelize) {
-    return queryInterface.bulkDelete('Endpoints', null, {});
+    return queryInterface.bulkDelete('endpoints', null, {});
   }
 };


### PR DESCRIPTION
The model and code all reference the table names in lower case however the migration and seeders reference the table names with the first character initialized.
![image](https://user-images.githubusercontent.com/1844164/234104770-4a84b474-754d-4fa6-ac4c-3db7152ee8d8.png)
